### PR TITLE
Use `echo` instead of `cat` for number that isn't a file path

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -419,7 +419,7 @@ There is no special syntax for multi-line comments - simply use a `#` at the sta
     # This comment will not be included within the command
     command <<<
       # This comment WILL be included within the command after it has been parsed
-      cat ~{number * 2}
+      echo ~{number * 2}
     >>>
 
     output {


### PR DESCRIPTION
Closes #654

`~{number * 2}` outputs a number, but `cat ~{number *2}` tries to read the file named that number, which doesn't work as that file does not exist. This test isn't testing reading from a file but from stdout, so `echo` should be more appropriate in printing the number to stdout.

I didn't add anything to the changelog as this is more of a bug fix.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
- [x] Valid examples WDL's were added or updated to the SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)
