### PR TITLE
Fix `false` in `all_true`

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -6340,7 +6340,7 @@ Example output:
 
 ```json
 {
-  "test_round.all_true": [true, false]
+  "test_round.all_true": [true, true]
 }
 ```
 </p>


### PR DESCRIPTION
Looks like we tuned the test to wrong behavior from MiniWDL. See https://github.com/chanzuckerberg/miniwdl/commit/7da1cc0b6074e52c0881b5530205795c9fa31ae7
